### PR TITLE
Fixed composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
   "name": "table/flip",
   "description": "（╯°□°）╯︵┻━┻",
-  "version": "1.0.0",
-  "minimum-stability": "stable",
   "license": "MIT",
   "authors": [
     {
@@ -11,7 +9,7 @@
     }
   ],
   "require-dev": {
-    "phpunit/phpunit": "4.8.x-dev"
+    "phpunit/phpunit": "~4.6"
   },
   "autoload": {
     "files": ["lib/flip.php"]


### PR DESCRIPTION
The "version" should never be specified in the composer.json file, the minimum stability isn't needed because the default is stable, and the version constraint for phpunit was wrong. `4.8.*@dev` was what you were looking for for, though I've selected `~4.6`.